### PR TITLE
Fix bug to install package

### DIFF
--- a/recipes/virusscan.rb
+++ b/recipes/virusscan.rb
@@ -20,8 +20,10 @@ windows_zipfile File.join(Chef::Config[:file_cache_path], node['mcafee']['viruss
   notifies :install, "windows_package[#{node['mcafee']['virusscan']['package_name']}]", :immediately
 end
 
+package = win_friendly_path(File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name'], 'SetupVSE.exe'))
+
 windows_package node['mcafee']['virusscan']['package_name'] do
-  source "File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name'], 'SetupVSE.exe')"
+  source #{package}
   options "ADDLOCAL=ALL RUNAUTOUPDATESILENTLY=True REMOVE=LotusNotesScan REBOOT=R /qn"
   installer_type :custom
   action :install


### PR DESCRIPTION
When using this version I assume in combination with the windows cookbook 1.36.1002 you get the following message:

Windows cannot find 'File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name'], 'SetupVSE.exe')'. Make sure you typed the name correctly, and then try again.

Please check the above change to also include a win_friendly_path the \ instead of / or another solution will be removing the quotes in line 26 (see below)

source "File.join(Chef::Config[:file_cache_path], node['mcafee']['virusscan']['package_name'], 'SetupVSE.exe')"